### PR TITLE
ci: rename GOOGLE_PLAY_APIKEY secret ref to GOOGLE_PLAY_API_KEY

### DIFF
--- a/.github/workflows/connect_publish.yml
+++ b/.github/workflows/connect_publish.yml
@@ -23,7 +23,7 @@ name: Publish Connect (All Platforms)
 #   secrets.ACCESS_KEY_DEFAULT_GOOGLE / _WEB                        (embedded default server key)
 #   secrets.ANDROID_KEYSTORE_GOOGLE_BASE64 / _PASSWORD             (Play signing)
 #   secrets.ANDROID_KEYSTORE_WEB_BASE64 / _PASSWORD                (web APK signing)
-# Shared org secrets are inherited: GOOGLE_PLAY_APIKEY, ADVANCED_INSTALLER_LICENSE,
+# Shared org secrets are inherited: GOOGLE_PLAY_API_KEY, ADVANCED_INSTALLER_LICENSE,
 #   AZURE_SIGNING_CREDENTIAL, AZURE_SIGNING_TARGET.
 
 on:
@@ -279,14 +279,14 @@ jobs:
           path: ${{ env.MODULE_DIR }}/${{ matrix.outdir }}/**
 
   # Publish the Android AAB to Google Play from the CI artifact, using THIS repo's fastlane config +
-  # the (org) GOOGLE_PLAY_APIKEY. This repo is checked out at ROOT, so fastlane (run from root) loads
+  # the (org) GOOGLE_PLAY_API_KEY. This repo is checked out at ROOT, so fastlane (run from root) loads
   # THIS repo's fastlane/ (com.vpnhood.connect.android) — never the monorepo's code/fastlane.
   publish-play-android:
     needs: [build-android]
     if: needs.build-android.result == 'success' && github.event.inputs.publish_play != 'false'
     runs-on: ubuntu-latest
     env:
-      GOOGLE_PLAY_APIKEY: ${{ secrets.GOOGLE_PLAY_APIKEY }}
+      GOOGLE_PLAY_API_KEY: ${{ secrets.GOOGLE_PLAY_API_KEY }}
     steps:
       - name: Checkout this repo (fastlane config, at root)
         uses: actions/checkout@v5
@@ -294,14 +294,14 @@ jobs:
         uses: actions/checkout@v5
         with: { repository: "${{ env.CODE_REPO }}", ref: "${{ github.event.inputs.ref || 'development' }}", path: code }
       - name: Warn if Google Play API key is missing
-        if: env.GOOGLE_PLAY_APIKEY == ''
-        run: echo "::warning title=Google Play publish skipped::GOOGLE_PLAY_APIKEY is not set; the AAB will NOT be uploaded to Google Play. The release proceeds without a Play-signed APK."
+        if: env.GOOGLE_PLAY_API_KEY == ''
+        run: echo "::warning title=Google Play publish skipped::GOOGLE_PLAY_API_KEY is not set; the AAB will NOT be uploaded to Google Play. The release proceeds without a Play-signed APK."
       - name: Download built AAB artifact
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         uses: actions/download-artifact@v8
         with: { name: connect-android-google-aab, path: aab }
       - name: Resolve version, track, and paths
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         shell: bash
         run: |
           set -e
@@ -337,19 +337,19 @@ jobs:
           } >> $GITHUB_ENV
           echo "✅ VersionName=$VERSION_NAME VersionCode=$VERSION_CODE Track=$TRACK Rollout='$ROLLOUT'"
       - name: Set up Java
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         uses: actions/setup-java@v5
         with: { distribution: temurin, java-version: "17" }
       - name: Set up Ruby
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         uses: ruby/setup-ruby@v1
         with: { ruby-version: "3.3", bundler-cache: false }
       - name: Install Fastlane
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         run: gem install fastlane --no-document
       # fastlane runs from the workspace ROOT -> loads THIS repo's fastlane/ (Connect's Appfile).
       - name: Upload AAB to Google Play (Fastlane)
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         run: |
           echo "Uploading $AAB_PATH (versionCode=$VERSION_CODE rollout='$ROLLOUT') to track $TRACK"
           # TEMP-CI-BINARY-ONLY: skip_metadata:"true" uploads only the AAB and leaves the live store
@@ -365,7 +365,7 @@ jobs:
             exit 1
           fi
       - name: Download Play-signed universal APK (Fastlane)
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         run: |
           fastlane android download_signed version_code:"$VERSION_CODE"
           SIGNED=$(find fastlane -type f -name "*.apk" | head -n1 || true)
@@ -375,7 +375,7 @@ jobs:
           cp "$SIGNED" "$GITHUB_WORKSPACE/play-signed/${BASE}.apk"
           echo "✅ Play-signed APK staged: play-signed/${BASE}.apk"
       - name: Upload Play-signed APK artifact
-        if: env.GOOGLE_PLAY_APIKEY != ''
+        if: env.GOOGLE_PLAY_API_KEY != ''
         uses: actions/upload-artifact@v7
         with:
           name: connect-android-play-signed

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ platform :android do
     skip_meta = options[:skip_metadata].to_s == 'true'
     upload_params = {
         aab: options[:aab],
-        json_key_data: ENV['GOOGLE_PLAY_APIKEY'],
+        json_key_data: ENV['GOOGLE_PLAY_API_KEY'],
         track: options[:track] || 'alpha',
         version_name: options[:version_name],
         version_code: options[:version_code],
@@ -61,7 +61,7 @@ platform :android do
 
     # Step 1: Fetch all active version codes from the production track
     production_versions = google_play_track_version_codes(
-      json_key_data: ENV['GOOGLE_PLAY_APIKEY'],
+      json_key_data: ENV['GOOGLE_PLAY_API_KEY'],
       track: 'production'
     )
 
@@ -77,7 +77,7 @@ platform :android do
     UI.message("   Note: Store contents are shared across all tracks")
     
     supply(
-      json_key_data: ENV['GOOGLE_PLAY_APIKEY'],
+      json_key_data: ENV['GOOGLE_PLAY_API_KEY'],
       version_code: latest_version_code,
       skip_upload_aab: true,
       skip_upload_apk: true,
@@ -98,7 +98,7 @@ platform :android do
       UI.user_error!("version_code is required. Pass via 'fastlane android download_signed version_code:123'.")
     end
     download_universal_apk_from_google_play(
-        json_key_data: ENV['GOOGLE_PLAY_APIKEY'],
+        json_key_data: ENV['GOOGLE_PLAY_API_KEY'],
         version_code: options[:version_code],
         destination: './fastlane/downloaded.apk'
     )


### PR DESCRIPTION
The shared **org** secret was renamed `GOOGLE_PLAY_APIKEY` → `GOOGLE_PLAY_API_KEY` (naming consistency with `NUGET_API_KEY`, `APPSTORE_CONNECT_API_KEY`, etc.). This repo inherits that org secret, so its references must match or the Google Play publish silently receives an empty key.

**Changes** (mechanical rename only):
- `.github/workflows/connect_publish.yml` — env mapping + all `env.GOOGLE_PLAY_APIKEY` guards
- `fastlane/Fastfile` — 4× `ENV['GOOGLE_PLAY_APIKEY']` reads

⚠️ Merge promptly: the org secret is **already** renamed, so `main` here is temporarily reading an empty Play key until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)