### PR TITLE
ci: build Connect from vpnhood/VpnHood (retire VpnHood-deploytest)

### DIFF
--- a/.github/workflows/connect_publish.yml
+++ b/.github/workflows/connect_publish.yml
@@ -1,6 +1,6 @@
 name: Publish Connect (All Platforms)
 
-# Builds VpnHood CONNECT from the monorepo code (vpnhood/VpnHood-deploytest) and releases it to THIS
+# Builds VpnHood CONNECT from the monorepo code (vpnhood/VpnHood) and releases it to THIS
 # repo (vpnhood/Vpnhood.App.Connect). The code is NOT forked here — it is checked out at build time
 # into code/; this repo only holds the release plumbing (this workflow + fastlane/ config + metadata)
 # and the Connect-specific secrets/variables. The monorepo remains the single source of code + version.
@@ -76,7 +76,7 @@ on:
 env:
   VH_CONNECT_PUBLISH_REPO: ${{ github.repository }}
   # The monorepo that holds the Connect source (public -> no checkout token needed).
-  CODE_REPO: vpnhood/VpnHood-deploytest
+  CODE_REPO: vpnhood/VpnHood
 
 jobs:
   build-linux:


### PR DESCRIPTION
`VpnHood-deploytest` was a legacy monorepo mirror and is being deleted. Point `CODE_REPO` at the canonical public **`vpnhood/VpnHood`** so every Connect platform build (Linux, Windows, Android, and the new iOS job) checks out the real source — which now carries the iOS scripts (`PrepareCiIosSigning.ps1 -appFolder`, `Src/Apps/Connect.Ios/_publish.ps1`).

One-line change: `CODE_REPO` + the header comment. No secrets/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)